### PR TITLE
POD update

### DIFF
--- a/lib/XS/Object/Magic.pm
+++ b/lib/XS/Object/Magic.pm
@@ -68,7 +68,9 @@ XS::Object::Magic - Opaque, extensible XS pointer backed objects using C<sv_magi
 
 	void foo (SV *self)
 		PREINIT:
-			my_struct_t *thingy = xs_object_magic_get_struct_rv(aTHX_ self)
+			my_struct_t *thingy;
+		INIT:
+			thingy; = xs_object_magic_get_struct_rv(aTHX_ self);
 		CODE:
 			my_struct_foo(thingy); /* delegate to C api */
 


### PR DESCRIPTION
Use INIT/PREINIT in POD in the example for xs_object_magic_get_struct_rv()

PREINIT can't call xs_object_magic_get_struct_rv() yet as the variable
"self" is not declared yet by the XS prprocessor.

The assignment to the variables has to be done in the INIT block and the
variable declaration in PREINIT.
