### PR TITLE
Add '.' to @INC in Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 
 
+use lib '.';
 use inc::Module::Install 0.91;
 use ExtUtils::Depends;
 


### PR DESCRIPTION
Perl 5.25.11 and newer (including the stable version 5.26.0) no
longer has the current directory '.' in the @INC path.